### PR TITLE
Import ErrorKind

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,6 @@ use std::convert::From;
 use std::ffi::{OsStr, OsString};
 use std::fmt::Display;
 use std::io::Error as IoError;
-#[cfg(feature = "http")]
 use std::io::ErrorKind;
 
 /// Any error that happens when opening a stream.


### PR DESCRIPTION
Currently there's a reference on L72 to `ErrorKind` that raises as undeclared without the `http` feature

Note that I got this when compiling PRQL with `wasm-pack`, and haven't looked deeply at the issue.