### PR TITLE
feat: extend MRSV to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: baptiste0928/cargo-install@v2
       with:
         crate: cargo-msrv
-        version: "^0.5"
     - name: Verify minimum rust version
       run: cargo msrv verify
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,14 @@ jobs:
       run: cargo +nightly doc --features http-ureq,clap-parse
       env:
         RUSTDOCFLAGS: --cfg docsrs
+
+    - uses: baptiste0928/cargo-install@v2
+      with:
+        crate: cargo-msrv
+        version: "^0.5"
+    - name: Verify minimum rust version
+      run: cargo msrv verify
+
   build:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
@@ -44,9 +52,3 @@ jobs:
       run: cargo test
     - name: Run clap & curl tests
       run: cargo test --features http-curl,clap-parse
-
-    - uses: baptiste0928/cargo-install@v2
-      with:
-        crate: cargo-msrv
-    - name: Verify minimum rust version
-      run: cargo msrv verify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,3 +44,9 @@ jobs:
       run: cargo test
     - name: Run clap & curl tests
       run: cargo test --features http-curl,clap-parse
+
+    - uses: baptiste0928/cargo-install@v2
+      with:
+        crate: cargo-msrv
+    - name: Verify minimum rust version
+      run: cargo msrv verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/aj-bagwell/clio"
 documentation = "https://docs.rs/clio"
 readme = "README.md"
 edition = "2021"
-rustversion = "1.63.0"
+rust-version = "1.63.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -31,7 +31,6 @@ cfg-if = "1.0.0"
 tempfile = "3.3.0"
 walkdir = "2.3.3"
 atty = "0.2.14"
-rustversion = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/aj-bagwell/clio"
 documentation = "https://docs.rs/clio"
 readme = "README.md"
 edition = "2021"
+rustversion = "1.63.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
@@ -30,6 +31,7 @@ cfg-if = "1.0.0"
 tempfile = "3.3.0"
 walkdir = "2.3.3"
 atty = "0.2.14"
+rustversion = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/path.rs
+++ b/src/path.rs
@@ -217,6 +217,7 @@ impl ClioPath {
     /// assert_eq!(ClioPath::new("/tmp/log.txt.gz")?, p);
     /// # Ok::<(), clio::Error>(())
     /// ```
+    #[rustversion::since(1.70)]
     pub fn add_extension<S: AsRef<OsStr>>(&mut self, extension: S) -> bool {
         if self.file_name().is_some() && !self.ends_with_slash() {
             self.with_path_mut(|path| {
@@ -224,6 +225,32 @@ impl ClioPath {
                 pathstr.push(".");
                 pathstr.push(extension);
             });
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Adds an extension to the end of the [`self.file_name`](Path::file_name).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use clio::ClioPath;
+    ///
+    /// let mut p = ClioPath::new("/tmp/log.txt")?;
+    ///
+    /// p.add_extension("gz");
+    /// assert_eq!(ClioPath::new("/tmp/log.txt.gz")?, p);
+    /// # Ok::<(), clio::Error>(())
+    /// ```
+    #[rustversion::before(1.70)]
+    pub fn add_extension<S: AsRef<OsStr>>(&mut self, extension: S) -> bool {
+        if self.file_name().is_some() && !self.ends_with_slash() {
+            let mut existing: OsString = self.extension().unwrap_or_default().to_os_string();
+            existing.push(".");
+            existing.push(extension);
+            self.with_path_mut(|path| path.set_extension(existing));
             true
         } else {
             false


### PR DESCRIPTION
Closes #https://github.com/aj-bagwell/clio/issues/13

Adds alternative implementation of `add_extension` function, which is slightly less efficient as it clones the path instead of mutating it.

This does add a dependency to `rustversion` for conditional compilation depending on Rust version. If that is not desired, `add_extension` function can be replaced completely.