### PR TITLE
Migrate from `atty` to `is-terminal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ url = { version = "2.3.1", optional = true }
 cfg-if = "1.0.0"
 tempfile = "3.3.0"
 walkdir = "2.3.3"
-atty = "0.2.14"
+is-terminal = "0.4.9"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/input.rs
+++ b/src/input.rs
@@ -4,6 +4,7 @@ use crate::path::{ClioPathEnum, InOut};
 use crate::{
     assert_exists, assert_not_dir, assert_readable, impl_try_from, is_fifo, ClioPath, Error, Result,
 };
+use is_terminal::IsTerminal;
 use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::fmt::{self, Debug, Display};
@@ -176,7 +177,7 @@ impl Input {
 
     /// Returns true if this is stdin and it is connected to a tty
     pub fn is_tty(&self) -> bool {
-        self.is_std() && atty::is(atty::Stream::Stdin)
+        self.is_std() && std::io::stdin().is_terminal()
     }
 
     /// Returns `true` if this [`Input`] is a file,
@@ -405,7 +406,7 @@ impl InputPath {
 
     /// Returns true if this is stdin and it is connected to a tty
     pub fn is_tty(&self) -> bool {
-        self.is_std() && atty::is(atty::Stream::Stdin)
+        self.is_std() && std::io::stdin().is_terminal()
     }
 
     /// Returns true if this [`InputPath`] is on the local file system,

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,6 +4,7 @@ use crate::{
     Result,
 };
 
+use is_terminal::IsTerminal;
 use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::fmt::{self, Debug, Display};
@@ -157,7 +158,7 @@ impl Output {
 
     /// Returns true if this is stdout and it is connected to a tty
     pub fn is_tty(&self) -> bool {
-        self.is_std() && atty::is(atty::Stream::Stdout)
+        self.is_std() && std::io::stdout().is_terminal()
     }
 
     /// Returns true if this Output is on the local file system,
@@ -341,7 +342,7 @@ impl OutputPath {
 
     /// Returns true if this is stdout and it is connected to a tty
     pub fn is_tty(&self) -> bool {
-        self.is_std() && atty::is(atty::Stream::Stdout)
+        self.is_std() && std::io::stdout().is_terminal()
     }
 
     /// Returns true if this [`Output`] is on the local file system,

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,5 +1,6 @@
 use crate::{impl_try_from, is_fifo, CachedInput, Input, Output, Result};
 
+use is_terminal::IsTerminal;
 use std::convert::TryFrom;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Debug, Display};
@@ -272,10 +273,10 @@ impl ClioPath {
     /// Returns true if this [`is_std`](Self::is_std) and it would connect to a tty
     pub fn is_tty(&self) -> bool {
         match self.path {
-            ClioPathEnum::Std(Some(InOut::In)) => atty::is(atty::Stream::Stdin),
-            ClioPathEnum::Std(Some(InOut::Out)) => atty::is(atty::Stream::Stdout),
+            ClioPathEnum::Std(Some(InOut::In)) => std::io::stdin().is_terminal(),
+            ClioPathEnum::Std(Some(InOut::Out)) => std::io::stdout().is_terminal(),
             ClioPathEnum::Std(None) => {
-                atty::is(atty::Stream::Stdin) || atty::is(atty::Stream::Stdout)
+                std::io::stdin().is_terminal() || std::io::stdout().is_terminal()
             }
             _ => false,
         }


### PR DESCRIPTION
`atty` is unmaintained and has security vulnerabilities.

See https://github.com/advisories/GHSA-g98v-hv3f-hcfr