### PR TITLE
Remove print from output.rs

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -303,7 +303,6 @@ impl OutputPath {
         let path: ClioPath = path.try_into()?.with_direction(InOut::Out);
         if path.is_local() {
             if path.is_file() && !path.atomic {
-                println!("{} is a file", path);
                 assert_writeable(&path)?;
             } else {
                 #[cfg(target_os = "linux")]


### PR DESCRIPTION
When attempting to use clio to create a cli application, I discovered that clio prints information while running. This PR removes the print.