### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,20 +23,20 @@ clap-parse = ["clap"]
 
 [dependencies]
 curl = { version = "0.4", optional = true }
-ureq = { version = "2.0", optional = true }
+ureq = { version = "2.9", optional = true }
 pipe = { version = "0.4", optional = true }
 clap = { version = ">=3.2, < 5.0", features = ["derive"], optional = true}
-url = { version = "2.3.1", optional = true }
+url = { version = "2.5.0", optional = true }
 cfg-if = "1.0.0"
-tempfile = "3.3.0"
-walkdir = "2.3.3"
-is-terminal = "0.4.9"
+tempfile = "3.10.1"
+walkdir = "2.5.0"
+is-terminal = "0.4.12"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.42", features = ["Win32_Foundation"] }
+windows-sys = { version = "0.52", features = ["Win32_Foundation"] }
 
 [dev-dependencies]
-clap = { version = "4.3.0", features = ["derive"] }
-either = "1.8.1"
+clap = { version = "4.0.32", features = ["derive"] }
+either = "1.11.0"


### PR DESCRIPTION
This avoids depending on both `windows-sys 0.42.0` and `windows-sys 0.52.0`.